### PR TITLE
feat: Flag tags to allow selection of scenarios

### DIFF
--- a/cmd/orion/run/run.go
+++ b/cmd/orion/run/run.go
@@ -18,6 +18,7 @@ const (
 	flagInputPath     = "input"
 	flagVariablesPath = "vars"
 	flagVerbose       = "verbose"
+	flagTags          = "tags"
 	defInputPath      = "feature.hcl"
 )
 
@@ -33,6 +34,7 @@ var (
 	`
 	inputPath     string
 	variablesPath string
+	tags          []string
 	verbose       string
 )
 
@@ -55,6 +57,11 @@ func New() *cobra.Command {
 		flagVariablesPath,
 		"",
 		"path of the variables file")
+	cmd.PersistentFlags().StringSliceVar(
+		&tags,
+		flagTags,
+		[]string{},
+		"comma separated list of tag names. Scenarios containing any of the listed tags will be executed.")
 	cmd.PersistentFlags().StringVar(
 		&verbose,
 		flagVerbose,
@@ -78,6 +85,15 @@ func run(cmd *cobra.Command, args []string) {
 		common.PrintError(cmd, err)
 		os.Exit(err.ExitStatus())
 	}
+
+	tags, tErr := cmd.PersistentFlags().GetStringSlice(flagTags)
+	if tErr != nil {
+		unexpected := errors.Unexpected("tags parse error: %s", tErr)
+		common.PrintError(cmd, unexpected)
+		os.Exit(unexpected.ExitStatus())
+	}
+	exec.WithTags(tags)
+
 	variablesPath := cmd.Flag(flagVariablesPath)
 	variables := make(map[string]cty.Value)
 	var err errors.Error

--- a/cmd/orion/run/testdata/feature001.hcl
+++ b/cmd/orion/run/testdata/feature001.hcl
@@ -1,4 +1,5 @@
 scenario "basic usage" {
+  tags = ["basic", "usage"]
   given "a couple of numbers" {
     set a {
       value = 1

--- a/docs/_gettingstarted/usage.md
+++ b/docs/_gettingstarted/usage.md
@@ -31,4 +31,5 @@ Execute the scenarios in the provided input file.
 Available flags:
 - `--input`: path of the input file.
 - `--vars`: path of the variables file.
+- `--tags`: comma separated list of tag names. Scenarios containing any of the listed tags will be executed.
 - `--verbose`: log level. Supported values are: 'DEBUG','INFO','WARN','ERROR' (default "INFO").

--- a/dsl/scenario.go
+++ b/dsl/scenario.go
@@ -148,6 +148,21 @@ func (s *Scenario) IsIgnored(ctx *hcl.EvalContext) bool {
 	return value.True()
 }
 
+func (s *Scenario) IsContainingAnyTag(expectedTags []string) bool {
+	sTags := make(map[string]bool)
+	for _, t := range s.Tags() {
+		sTags[t] = true
+	}
+
+	for _, et := range expectedTags {
+		if sTags[et] {
+			log.Debugf("Tag found: '%s'", et)
+			return true
+		}
+	}
+	return false
+}
+
 func decodeScenario(b *hcl.Block) (*Scenario, errors.Error) {
 	scenario := &Scenario{
 		description: b.Labels[0],


### PR DESCRIPTION
This PR addresses https://github.com/wesovilabs/orion/issues/5

Added `--tags` flag.
This will allow a user to supply a csv string of possible tags.
Scenario which contain any of the listed tags will be executed.

Possibly, the tags could be saved in the OrionContext/EvalContext and simplify life with the IsSkipped.