### PR TITLE
feat: action `sleep`

### DIFF
--- a/actions/block/block.go
+++ b/actions/block/block.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wesovilabs/orion/actions/mongo"
 	pprint "github.com/wesovilabs/orion/actions/print"
 	"github.com/wesovilabs/orion/actions/set"
+	"github.com/wesovilabs/orion/actions/sleep"
 	"github.com/wesovilabs/orion/context"
 	"github.com/wesovilabs/orion/internal/errors"
 )
@@ -20,23 +21,25 @@ const (
 )
 
 var decoders = map[string]actions.Decoder{
-	set.BlockSet:       new(set.Decoder),
 	assert.BlockAssert: new(assert.Decoder),
-	pprint.BlockPrint:  new(pprint.Decoder),
+	call.BlockCall:     new(call.Decoder),
 	http.BlockHTTP:     new(http.Decoder),
 	mongo.BlockMongo:   new(mongo.Decoder),
-	call.BlockCall:     new(call.Decoder),
+	pprint.BlockPrint:  new(pprint.Decoder),
+	set.BlockSet:       new(set.Decoder),
+	sleep.BlockSleep:   new(sleep.Decoder),
 }
 
 var schemaBlock = &hcl.BodySchema{
 	Attributes: actions.BaseArguments,
 	Blocks: []hcl.BlockHeaderSchema{
 		decoders[assert.BlockAssert].BlockHeaderSchema(),
-		decoders[set.BlockSet].BlockHeaderSchema(),
-		decoders[pprint.BlockPrint].BlockHeaderSchema(),
+		decoders[call.BlockCall].BlockHeaderSchema(),
 		decoders[http.BlockHTTP].BlockHeaderSchema(),
 		decoders[mongo.BlockMongo].BlockHeaderSchema(),
-		decoders[call.BlockCall].BlockHeaderSchema(),
+		decoders[pprint.BlockPrint].BlockHeaderSchema(),
+		decoders[set.BlockSet].BlockHeaderSchema(),
+		decoders[sleep.BlockSleep].BlockHeaderSchema(),
 	},
 }
 

--- a/actions/register/decoder.go
+++ b/actions/register/decoder.go
@@ -10,27 +10,30 @@ import (
 	"github.com/wesovilabs/orion/actions/mongo"
 	pprint "github.com/wesovilabs/orion/actions/print"
 	"github.com/wesovilabs/orion/actions/set"
+	"github.com/wesovilabs/orion/actions/sleep"
 )
 
 var decoders = map[string]actions.Decoder{
-	set.BlockSet:       new(set.Decoder),
 	assert.BlockAssert: new(assert.Decoder),
-	pprint.BlockPrint:  new(pprint.Decoder),
-	http.BlockHTTP:     new(http.Decoder),
-	mongo.BlockMongo:   new(mongo.Decoder),
 	block.BlockBlock:   new(block.Decoder),
 	call.BlockCall:     new(call.Decoder),
+	http.BlockHTTP:     new(http.Decoder),
+	mongo.BlockMongo:   new(mongo.Decoder),
+	pprint.BlockPrint:  new(pprint.Decoder),
+	set.BlockSet:       new(set.Decoder),
+	sleep.BlockSleep:   new(sleep.Decoder),
 }
 
 var schemaPlugins = &hcl.BodySchema{
 	Attributes: nil,
 	Blocks: []hcl.BlockHeaderSchema{
-		decoders[set.BlockSet].BlockHeaderSchema(),
 		decoders[assert.BlockAssert].BlockHeaderSchema(),
-		decoders[pprint.BlockPrint].BlockHeaderSchema(),
-		decoders[http.BlockHTTP].BlockHeaderSchema(),
-		decoders[mongo.BlockMongo].BlockHeaderSchema(),
 		decoders[block.BlockBlock].BlockHeaderSchema(),
 		decoders[call.BlockCall].BlockHeaderSchema(),
+		decoders[http.BlockHTTP].BlockHeaderSchema(),
+		decoders[mongo.BlockMongo].BlockHeaderSchema(),
+		decoders[pprint.BlockPrint].BlockHeaderSchema(),
+		decoders[set.BlockSet].BlockHeaderSchema(),
+		decoders[sleep.BlockSleep].BlockHeaderSchema(),
 	},
 }

--- a/actions/sleep/action.go
+++ b/actions/sleep/action.go
@@ -1,0 +1,43 @@
+package sleep
+
+import (
+	"time"
+
+	"github.com/hashicorp/hcl/v2"
+	log "github.com/sirupsen/logrus"
+	"github.com/wesovilabs/orion/actions"
+	"github.com/wesovilabs/orion/context"
+	"github.com/wesovilabs/orion/helper"
+	"github.com/wesovilabs/orion/internal/errors"
+)
+
+var defSleepDuration = 1 * time.Second
+
+type Sleep struct {
+	*actions.Base
+	duration hcl.Expression
+}
+
+func (s *Sleep) SetDuration(expr hcl.Expression) {
+	s.duration = expr
+}
+
+func (s *Sleep) Duration(ctx *hcl.EvalContext) (time.Duration, errors.Error) {
+	sleepDuration, err := helper.GetExpressionValueAsDuration(ctx, s.duration, &defSleepDuration)
+	return *sleepDuration, err
+}
+
+// Execute function in charge of executing the plugin.
+func (s *Sleep) Execute(ctx context.OrionContext) errors.Error {
+	return actions.Execute(ctx, s.Base, func(ctx context.OrionContext) errors.Error {
+		duration, err := s.Duration(ctx.EvalContext())
+		if err != nil {
+			return err
+		}
+
+		log.Tracef("sleeping for duration %v", duration)
+		time.Sleep(duration)
+
+		return nil
+	})
+}

--- a/actions/sleep/action_test.go
+++ b/actions/sleep/action_test.go
@@ -1,0 +1,47 @@
+package sleep
+
+import (
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wesovilabs/orion/actions/shared"
+	"github.com/wesovilabs/orion/context"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const (
+	featuresDir     = "testdata"
+	featureScenario = "scenario1.hcl"
+)
+
+var decoder = new(Decoder)
+
+func TestSleep(t *testing.T) {
+	content, err := shared.GetBodyContent(path.Join(featuresDir, featureScenario), BlockSleep, []string{})
+	assert.Nil(t, err)
+	assert.NotNil(t, content)
+
+	ctx := context.New(map[string]cty.Value{}, nil)
+
+	for i := range content.Blocks {
+		action, err := decoder.DecodeBlock(content.Blocks[i])
+		assert.Nil(t, err)
+		assert.NotNil(t, action)
+
+		s, ok := action.(*Sleep)
+		assert.True(t, ok)
+		assert.NotNil(t, s)
+
+		duration, err := s.Duration(ctx.EvalContext())
+		assert.Nil(t, err)
+		assert.Equal(t, 10*time.Millisecond, duration)
+
+		start := time.Now()
+		s.Execute(ctx)
+		actualDuration := time.Now().Sub(start)
+		assert.GreaterOrEqual(t, actualDuration.Milliseconds(), duration.Milliseconds())
+		assert.LessOrEqual(t, actualDuration.Milliseconds(), duration.Milliseconds()+10)
+	}
+}

--- a/actions/sleep/decoder.go
+++ b/actions/sleep/decoder.go
@@ -1,0 +1,63 @@
+package sleep
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/wesovilabs/orion/actions"
+	"github.com/wesovilabs/orion/internal/errors"
+)
+
+const (
+	// BlockSleep identifier of the sleep block.
+	BlockSleep = "sleep"
+	// AttributeDuration name of the argument used to specify the sleep duration.
+	AttributeDuration = "duration"
+)
+
+var schemaSleep = &hcl.BodySchema{
+	Attributes: append(actions.BaseArguments, []hcl.AttributeSchema{
+		{Name: AttributeDuration, Required: true},
+	}...),
+}
+
+// Decoder implements interface plugin.Decoder.
+type Decoder struct{}
+
+// BlockHeaderSchema return the header schema for the plugin.
+func (dec *Decoder) BlockHeaderSchema() hcl.BlockHeaderSchema {
+	return hcl.BlockHeaderSchema{
+		Type:       BlockSleep,
+		LabelNames: nil,
+	}
+}
+
+// DecodeBlock required to implement the plugin interface.
+func (dec *Decoder) DecodeBlock(block *hcl.Block) (actions.Action, errors.Error) {
+	bodyContent, d := block.Body.Content(schemaSleep)
+	if err := errors.EvalDiagnostics(d); err != nil {
+		return nil, err
+	}
+	assert := &Sleep{Base: &actions.Base{}}
+	if err := populateAttributes(assert, bodyContent.Attributes); err != nil {
+		return nil, err
+	}
+	return assert, nil
+}
+
+func populateAttributes(s *Sleep, attrs hcl.Attributes) errors.Error {
+	for name := range attrs {
+		attribute := attrs[name]
+
+		switch {
+		case actions.IsCommonAttribute(name):
+			if err := actions.SetBaseArgs(s, attribute); err != nil {
+				return err
+			}
+		case name == AttributeDuration:
+			s.SetDuration(attribute.Expr)
+		default:
+			return errors.ThrowUnsupportedArgument(BlockSleep, name)
+		}
+	}
+
+	return nil
+}

--- a/actions/sleep/decoder_test.go
+++ b/actions/sleep/decoder_test.go
@@ -1,0 +1,59 @@
+package sleep
+
+import (
+	"path"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/assert"
+	"github.com/wesovilabs/orion/actions/shared"
+)
+
+var assertDecoderPath = path.Join(
+	featuresDir, featureScenario,
+)
+
+var assertDecoderBlocks = []*Sleep{
+	{
+		duration: &hclsyntax.TemplateExpr{
+			SrcRange: hcl.Range{
+				Filename: assertDecoderPath,
+				Start:    shared.CreatePos(2, 3, 10),
+				End:      shared.CreatePos(2, 20, 27),
+			},
+		},
+	},
+}
+
+func TestDecoder_DecodeBlock(t *testing.T) {
+	content, err := shared.GetBodyContent(assertDecoderPath, BlockSleep, []string{})
+	assert.Nil(t, err)
+	assert.NotNil(t, content)
+
+	assert.Len(t, content.Blocks, len(assertDecoderBlocks))
+	for index := range content.Blocks {
+		block := content.Blocks[index]
+		expectedBlock := assertDecoderBlocks[index]
+		assertBlockAssert(t, block, expectedBlock)
+	}
+}
+
+func assertBlockAssert(t *testing.T, block *hcl.Block, s *Sleep) {
+	assert.Len(t, block.Labels, 0)
+	assert.Equal(t, BlockSleep, block.Type)
+	c, d := block.Body.Content(schemaSleep)
+	assert.Nil(t, d)
+	assert.NotNil(t, c)
+	for name := range c.Attributes {
+		attribute := c.Attributes[name]
+		switch name {
+		case AttributeDuration:
+			assert.NotNil(t, s.duration)
+			assert.Equal(t, s.duration.Range().Start, attribute.Range.Start)
+			assert.Equal(t, s.duration.Range().End, attribute.Range.End)
+		default:
+			assert.Failf(t, "error", "unexpected attribute %s", name)
+		}
+	}
+}

--- a/actions/sleep/testdata/scenario1.hcl
+++ b/actions/sleep/testdata/scenario1.hcl
@@ -1,0 +1,3 @@
+sleep {
+  duration = "10ms"
+}

--- a/docs/_spec/actions/index.md
+++ b/docs/_spec/actions/index.md
@@ -16,8 +16,9 @@ Documentation and examples of the existing actions can be found on the below lin
 - [assert](../assert)
 - [http](../http)
 - [mongo](../mongo).
-- [block](../block).
 - [call](../call).
+- [sleep](../sleep).
+- [block](../block).
 
 New actions are in progress: `graphql`, `grpc`, `mysql` and `postgres` among others. 
 

--- a/docs/_spec/actions/sleep.md
+++ b/docs/_spec/actions/sleep.md
@@ -1,33 +1,13 @@
 ---
 layout: default
-title: block
+title: sleep
 parent: Actions
-nav_order: 8
+nav_order: 7
 ---
 <link rel="stylesheet" href="../../../assets/css/custom.css">
-# block
-It  is used to group a set of actions.
+# sleep
 
-```hcl
-block {
-    set carOwner {
-        value = "John Doe"
-    }
-    print {
-        msg = "the owner of the car is ${carOwner}"
-    }
-    when = car.color=="red"
-}
-```
-
-**Supported actions:**
-- [set](../set)
-- [print](../print)
-- [assert](../assert)
-- [http](../http)
-- [mongo](../mongo)
-- [call](../call)
-- [sleep](../sleep)
+The action **sleep** is used to pause the execution for a specified duration.
 
 ## Specification
 
@@ -35,19 +15,31 @@ block {
 
 |                 | Tpye      | Required?| Vars supported? |
 |:----------------|:----------|---------:|----------------:|
+| **duration**    | duration  | yes      | yes             |
 | **description** | string    | no       | no              |
 | **while**       | boolean   | no       | yes             |
 | **when**        | boolean   | no       | yes             |
 | **count**       | numeric   | no       | yes             |
 
 
+**duration** ( duration \| required ) : It specified the `time.duration` to pause the execution.
+
+*Example 1: Basic use of argument duration*
+
+```hcl
+sleep {
+  duration = "2s"
+}
+```
+---
 **description** ( string \| optional )  It is used to apply descriptive text to  the action.
 
 *Example 1: Basic use of argument*
 
 ```hcl
-block{
-  description = "a new person is created and registered."
+sleep {
+  description = "this statement is used to pause the execution for 2 seconds"
+  duration = "2s"
 }
 ```
 ---
@@ -58,28 +50,28 @@ var {
   evalJobStatus = false
 }
 
-block{
-  when = evalJobStatus
+sleep {
+  duration = "2s"
+  when = evalJobStatus && exists(job)
 }
 ```
 ---
-**count** ( number || optional ) It determines the number of times the action is executed. Additionally, the variable **_.index** is increased in each iteration. 
-The value of _.index starts with 0 and it ends with count-1.
+**count** ( number || optional ) It determines the number of times the action is executed.
 
-*Example 1: Basic use of the argument*
+*Example 1: Basic use of the argument count*
 ```hcl
-block {
-
+sleep {
+  duration = "2s"
   count = 3
 }
 ```
-
 ---
 **while** ( boolean \| optional )  The action is executed repeatedly as long as the value of this argument is met. Additionally, the variable **_.index** is increased in each iteration. The value of _.index starts with 0 and increase in 1 in each iteration.
 
 *Example 1: Basic use of argument while*
 ```hcl
-block {
+assert {
+  duraiton = "2s"
   while = _.index<=2
 }
 ```


### PR DESCRIPTION
Added action sleep as per https://github.com/wesovilabs/orion/issues/9

The timeout example scenario utilizes string for example "10s", however the documentation mentiones timeout = 10s

![Screenshot from 2021-03-04 00-00-25](https://user-images.githubusercontent.com/1005989/109878229-acb0f800-7c7c-11eb-8f7a-1f0d7060447b.png)

![Screenshot from 2021-03-04 00-01-13](https://user-images.githubusercontent.com/1005989/109878310-cb16f380-7c7c-11eb-93b6-347ec6885ed1.png)

Given code is likely to be correct than doc, I went with that. Even the hcl plugin in my IDE was giving me error with `duration = 1s`

I can fix the documentation next if this is fine.